### PR TITLE
prepare next release version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 
   <groupId>com.hubspot.guice</groupId>
   <artifactId>guice-transactional</artifactId>
-  <version>0.2.4-SNAPSHOT</version>
+  <version>0.3.0-SNAPSHOT</version>
 
   <dependencyManagement>
     <dependencies>


### PR DESCRIPTION
Bumping to 0.3.0 to signify new jdk target (8 -> 11) and new guice version (4.x -> 5.x)