### PR TITLE
rename TransactionHolder to TransactionalInterceptor

### DIFF
--- a/src/main/java/com/hubspot/guice/transactional/TransactionalDataSource.java
+++ b/src/main/java/com/hubspot/guice/transactional/TransactionalDataSource.java
@@ -1,7 +1,7 @@
 package com.hubspot.guice.transactional;
 
-import com.hubspot.guice.transactional.impl.TransactionHolder;
 import com.hubspot.guice.transactional.impl.TransactionalConnection;
+import com.hubspot.guice.transactional.impl.TransactionalInterceptor;
 import java.io.PrintWriter;
 import java.sql.Connection;
 import java.sql.SQLException;
@@ -21,13 +21,13 @@ public class TransactionalDataSource implements DataSource {
 
   @Override
   public Connection getConnection() throws SQLException {
-    if (TransactionHolder.inTransaction()) {
-      TransactionalConnection connection = TransactionHolder.getTransaction();
+    if (TransactionalInterceptor.inTransaction()) {
+      TransactionalConnection connection = TransactionalInterceptor.getTransaction();
       if (connection == null) {
         Connection delegateConnection = delegate.getConnection();
         ensureDbNamePopulated(delegateConnection);
         connection = new TransactionalConnection(delegateConnection, getDbName());
-        TransactionHolder.setTransaction(connection);
+        TransactionalInterceptor.setTransaction(connection);
       }
       throwIfConnectionInvalid(connection);
 
@@ -41,13 +41,13 @@ public class TransactionalDataSource implements DataSource {
 
   @Override
   public Connection getConnection(String username, String password) throws SQLException {
-    if (TransactionHolder.inTransaction()) {
-      TransactionalConnection connection = TransactionHolder.getTransaction();
+    if (TransactionalInterceptor.inTransaction()) {
+      TransactionalConnection connection = TransactionalInterceptor.getTransaction();
       if (connection == null) {
         Connection delegateConnection = delegate.getConnection(username, password);
         ensureDbNamePopulated(delegateConnection);
         connection = new TransactionalConnection(delegateConnection, getDbName());
-        TransactionHolder.setTransaction(connection);
+        TransactionalInterceptor.setTransaction(connection);
       }
       throwIfConnectionInvalid(connection);
 

--- a/src/main/java/com/hubspot/guice/transactional/impl/AbstractTransactionalInterceptor.java
+++ b/src/main/java/com/hubspot/guice/transactional/impl/AbstractTransactionalInterceptor.java
@@ -1,7 +1,7 @@
 package com.hubspot.guice.transactional.impl;
 
-import static com.hubspot.guice.transactional.impl.TransactionHolder.IN_TRANSACTION;
-import static com.hubspot.guice.transactional.impl.TransactionHolder.TRANSACTION_HOLDER;
+import static com.hubspot.guice.transactional.impl.TransactionalInterceptor.IN_TRANSACTION;
+import static com.hubspot.guice.transactional.impl.TransactionalInterceptor.TRANSACTION_HOLDER;
 
 import com.hubspot.guice.transactional.impl.TransactionalAdapter.TxType;
 import org.aopalliance.intercept.MethodInterceptor;

--- a/src/main/java/com/hubspot/guice/transactional/impl/TransactionalInterceptor.java
+++ b/src/main/java/com/hubspot/guice/transactional/impl/TransactionalInterceptor.java
@@ -1,6 +1,6 @@
 package com.hubspot.guice.transactional.impl;
 
-public class TransactionHolder {
+public class TransactionalInterceptor {
 
   protected static final ThreadLocal<TransactionalConnection> TRANSACTION_HOLDER =
     new ThreadLocal<>();


### PR DESCRIPTION
This brings back public API removed in 0.4.0 with the renamed class.